### PR TITLE
Add an idempotency checker for API calls.

### DIFF
--- a/feature-server/src/main/java/outland/feature/server/ServerModule.java
+++ b/feature-server/src/main/java/outland/feature/server/ServerModule.java
@@ -2,6 +2,8 @@ package outland.feature.server;
 
 import com.google.inject.AbstractModule;
 import outland.feature.server.resources.HelloResource;
+import outland.feature.server.resources.IdempotencyChecker;
+import outland.feature.server.resources.IdempotencyCheckerRedis;
 
 public class ServerModule extends AbstractModule {
 
@@ -15,5 +17,7 @@ public class ServerModule extends AbstractModule {
   protected void configure() {
     bind(ServerConfiguration.class).toInstance(configuration);
     bind(HelloResource.class).asEagerSingleton();
+
+    bind(IdempotencyChecker.class).to(IdempotencyCheckerRedis.class).asEagerSingleton();
   }
 }

--- a/feature-server/src/main/java/outland/feature/server/resources/IdempotencyChecker.java
+++ b/feature-server/src/main/java/outland/feature/server/resources/IdempotencyChecker.java
@@ -1,0 +1,16 @@
+package outland.feature.server.resources;
+
+import java.util.Optional;
+import javax.ws.rs.core.HttpHeaders;
+
+public interface IdempotencyChecker {
+
+  String REQ_HEADER = "Idempotency-Key";
+  String RES_HEADER = "Idempotency-Key-Trace";
+
+  default Optional<String> extractKey(HttpHeaders httpHeaders) {
+    return Optional.ofNullable(httpHeaders.getHeaderString(IdempotencyChecker.REQ_HEADER));
+  }
+
+  boolean seen(String idempotencyKey);
+}

--- a/feature-server/src/main/java/outland/feature/server/resources/IdempotencyCheckerRedis.java
+++ b/feature-server/src/main/java/outland/feature/server/resources/IdempotencyCheckerRedis.java
@@ -1,0 +1,49 @@
+package outland.feature.server.resources;
+
+import java.util.Map;
+import javax.inject.Inject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import outland.feature.server.redis.RedisProvider;
+import redis.clients.jedis.Jedis;
+
+import static outland.feature.server.StructLog.kvp;
+
+public class IdempotencyCheckerRedis implements IdempotencyChecker {
+
+  private static final Logger logger = LoggerFactory.getLogger(IdempotencyCheckerRedis.class);
+
+  private static final int TTL_SECONDS = 3600 * 24;
+
+  private final RedisProvider redisProvider;
+
+  @Inject
+  public IdempotencyCheckerRedis(Map<String, RedisProvider> providers) {
+    this.redisProvider = providers.get("outland_feature_idempotency_check_redis");
+  }
+
+  public boolean seen(String idempotencyKey) {
+
+    if (idempotencyKey == null) {
+      return false;
+    }
+
+    Jedis jedis = null;
+
+    try {
+      jedis = redisProvider.get();
+      String cacheKey = "outland:feature:idem_key:" + idempotencyKey;
+      final Long res = jedis.setnx(cacheKey, "");
+      jedis.expire(cacheKey, TTL_SECONDS);
+      return res == 0;
+    } catch (Exception e) {
+      logger.error("{}", kvp("op", "idempotency_check",
+          "key", idempotencyKey,
+          "err", "[" + e.getMessage() + "]"));
+    } finally {
+      redisProvider.closeSafely(jedis);
+    }
+
+    return false;
+  }
+}

--- a/feature-server/src/test/java/outland/feature/server/resources/IdempotencyCheckerTest.java
+++ b/feature-server/src/test/java/outland/feature/server/resources/IdempotencyCheckerTest.java
@@ -1,0 +1,44 @@
+package outland.feature.server.resources;
+
+import com.google.common.collect.Lists;
+import com.google.inject.AbstractModule;
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import org.junit.Test;
+import outland.feature.server.features.Ulid;
+import outland.feature.server.redis.RedisConfiguration;
+import outland.feature.server.redis.RedisModule;
+import outland.feature.server.redis.RedisServersConfiguration;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class IdempotencyCheckerTest {
+
+  @Test
+  public void testCheck() {
+
+    RedisConfiguration rc = new RedisConfiguration();
+    rc.name = "outland_feature_idempotency_check_redis";
+    RedisServersConfiguration rsc = new RedisServersConfiguration();
+    rsc.servers = Lists.newArrayList(rc);
+
+    final Injector injector = Guice.createInjector(
+        new RedisModule(rsc),
+        new AbstractModule() {
+          @Override protected void configure() {
+            bind(IdempotencyChecker.class).to(IdempotencyCheckerRedis.class).asEagerSingleton();
+          }
+        }
+    );
+
+    final IdempotencyChecker checker = injector.getInstance(IdempotencyChecker.class);
+
+    final String key = Ulid.random();
+    assertFalse(checker.seen(key));
+    assertTrue(checker.seen(key));
+
+    assertFalse(checker.seen(Ulid.random()));
+    assertFalse(checker.seen(Ulid.random()));
+  }
+}


### PR DESCRIPTION
This can be used to trap API requests with Idempotency-Key headers and
detect if they've been seen before. The implementation uses redis setnx
to check and record keys.