### PR TITLE
Adds versioning support to the API server.

### DIFF
--- a/outland-feature-server/src/main/java/outland/feature/server/features/VersionService.java
+++ b/outland-feature-server/src/main/java/outland/feature/server/features/VersionService.java
@@ -1,0 +1,53 @@
+package outland.feature.server.features;
+
+import com.google.common.base.MoreObjects;
+
+public interface VersionService {
+
+  HybridLogicalTimestamp nextVersion();
+
+  HybridLogicalTimestamp nextVersionUpdate(HybridLogicalTimestamp incoming);
+
+  interface Clock {
+    long timestampMicros();
+  }
+
+  class HybridLogicalTimestamp {
+    private final long logicalTime;
+    private final long counter;
+
+    HybridLogicalTimestamp(long logicalTime, long counter) {
+      this.logicalTime = logicalTime;
+      this.counter = counter;
+    }
+
+    public long logicalTime() {
+      return logicalTime;
+    }
+
+    public long counter() {
+      return counter;
+    }
+
+    String asUlid() {
+      return Ulid.generate(asTimestampMillis(),
+          ("localTime=" + logicalTime + ",counter=" + counter).getBytes());
+    }
+
+    long asTimestampMicros() {
+      // 16 and 48 are taken from https://www.cse.buffalo.edu/tech-reports/2014-04.pdf
+      return (logicalTime >> 16 << 16) | (counter << 48 >> 48);
+    }
+
+    long asTimestampMillis() {
+      return asTimestampMicros() / 1000L;
+    }
+
+    @Override public String toString() {
+      return MoreObjects.toStringHelper(this)
+          .add("logicalTime", logicalTime)
+          .add("counter", counter)
+          .toString();
+    }
+  }
+}

--- a/outland-feature-server/src/main/java/outland/feature/server/features/Versions.java
+++ b/outland-feature-server/src/main/java/outland/feature/server/features/Versions.java
@@ -1,0 +1,167 @@
+package outland.feature.server.features;
+
+import java.util.concurrent.atomic.AtomicLong;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static outland.feature.server.StructLog.kvp;
+
+class Versions implements VersionService {
+
+  private static final Logger logger = LoggerFactory.getLogger(Versions.class);
+
+  private static final long ONE_HOUR_MICROSECONDS = 3600L * 1000L * 1000L;
+
+  // no idea what are good values here, let's do it live
+  static final long MAX_SYSTEM_TIME_FORWARD_DRIFT = 12 * ONE_HOUR_MICROSECONDS;
+  private static final long MAX_INCOMING_TIME_FORWARD_DRIFT = 12 * ONE_HOUR_MICROSECONDS;
+
+  private final Clock clock;
+  private final AtomicLong localTime;
+  private final AtomicLong localCounter;
+
+  Versions(Clock clock) {
+    this.clock = clock;
+    // todo: accept these as values, to allow us to memo logicalTime from previous starts
+    localTime = new AtomicLong(clock.timestampMicros());
+    localCounter = new AtomicLong(0L);
+  }
+
+  Versions() {
+    this(new SystemClock());
+  }
+
+  @Override
+  public HybridLogicalTimestamp nextVersion() {
+
+    final long physicalNow = this.clock.timestampMicros();
+
+    if (localTime.get() >= physicalNow) {
+      //physical clock hasn't moved forward relative to local, keep the logicalTime, bump counter
+      localCounter.incrementAndGet();
+      traceBackwardDrift(physicalNow, localTime.get());
+    } else {
+      // the physical clock is ahead
+
+      /*
+       a hack to handle the 2051 problem; if our system clock is "too" far ahead of our local
+       logicalTime then all future versions get dragged forward to keep up with it and we have
+       to wait for "reality" to catch up with that logicalTime to reset things.
+
+       todo: this misses the case where the clock is borked on construction;
+       in the ctor we set the initial local to the physical clock, so this only catches drift
+       when updating the local. it also needs some thought such that if multiple nodes are stuck
+       on fwd/back physical times and just bumping counters they don't clash.
+        */
+      if (physicalNowTooFarAhead(physicalNow, localTime)) {
+        localCounter.incrementAndGet();
+        traceForwardDrift(physicalNow, localTime.get());
+      } else {
+        // things look sane, take the physical logicalTime and reset the counter
+        localTime.set(physicalNow);
+        localCounter.set(0L);
+      }
+    }
+
+    return new HybridLogicalTimestamp(localTime.get(), localCounter.get());
+  }
+
+  @Override
+  public HybridLogicalTimestamp nextVersionUpdate(HybridLogicalTimestamp incoming) {
+    final long physicalNow = this.clock.timestampMicros();
+
+    if (physicalNow > localTime.get() && physicalNow > incoming.logicalTime()) {
+      if (!physicalNowTooFarAhead(physicalNow, localTime)) {
+        localTime.set(physicalNow);
+        localCounter.set(0L);
+      } else {
+        // don't use our physical logicalTime, it's too far ahead
+        traceForwardDrift(physicalNow, localTime.get());
+        resolveLocalAndIncomingTimestamps(incoming);
+      }
+    } else {
+      // don't use our physical logicalTime, it's either same as or behind us
+      traceBackwardDrift(physicalNow, localTime.get(), incoming.logicalTime());
+      resolveLocalAndIncomingTimestamps(incoming);
+    }
+
+    return new HybridLogicalTimestamp(localTime.get(), localCounter.get());
+  }
+
+  private boolean physicalNowTooFarAhead(long physicalNow, AtomicLong logicalTime) {
+    return (physicalNow - logicalTime.get()) > MAX_SYSTEM_TIME_FORWARD_DRIFT;
+  }
+
+  private void resolveLocalAndIncomingTimestamps(HybridLogicalTimestamp incoming) {
+    if (localTime.get() > incoming.logicalTime()) {
+      localCounter.incrementAndGet();
+    } else if (localTime.get() < incoming.logicalTime()) {
+
+      // todo: 2051 problem possible as there's no drift check, but log it
+      if ((incoming.logicalTime() - localTime.get()) > MAX_INCOMING_TIME_FORWARD_DRIFT) {
+        traceIncomingForwardDrift(localTime.get(), incoming.logicalTime());
+      }
+
+      localTime.set(incoming.logicalTime());
+      localCounter.set(incoming.counter() + 1);
+    } else { // times are equal, pick the highest counter and bump it
+      if (incoming.counter() > localCounter.get()) {
+        localCounter.set(incoming.counter() + 1);
+      } else {
+        localCounter.incrementAndGet();
+      }
+    }
+  }
+
+  private void traceForwardDrift(long physicalNow, long localTime) {
+    logger.error(kvp("op", "version_timestamp",
+        "err", "physical_time_drift_forward",
+        "my_logical_time", "" + localTime,
+        "my_physical_time", "" + physicalNow,
+        "local_drift", "" + (physicalNow - localTime),
+        "allowed_drift", "" + MAX_SYSTEM_TIME_FORWARD_DRIFT
+    ));
+  }
+
+  private void traceIncomingForwardDrift(long localTime, long incomingTime) {
+    logger.error(kvp("op", "version_timestamp",
+        "err", "incoming_time_drift_forward",
+        "my_logical_time", "" + localTime,
+        "their_logical_time", "" + incomingTime,
+        "relative_drift", "" + (incomingTime - localTime),
+        "allowed_drift", "" + MAX_INCOMING_TIME_FORWARD_DRIFT
+    ));
+  }
+
+  private void traceBackwardDrift(long physicalNow, long localTime, long incoming) {
+    logger.error(kvp("op", "version_timestamp",
+        "err", "physical_time_drift_backward",
+        "my_logical_time", "" + localTime,
+        "my_physical_time", "" + physicalNow,
+        "their_logical_time", "" + incoming,
+        "local_drift", "" + (localTime - physicalNow),
+        "remote_drift", "" + (incoming - physicalNow)
+    ));
+  }
+
+  private void traceBackwardDrift(long physicalNow, long localTime) {
+    logger.error(kvp("op", "version_timestamp",
+        "err", "physical_time_drift_backward",
+        "my_logical_time", "" + localTime,
+        "my_physical_time", "" + physicalNow,
+        "local_drift", "" + (localTime - physicalNow)
+    ));
+  }
+
+  static class SystemClock implements Clock {
+
+    @Override
+    public long timestampMicros() {
+      /*
+       todo: we might want to sample ntp servers for a hyparview based system,
+        we can probably live with cTM for client/server
+        */
+      return System.currentTimeMillis() * 1000L;
+    }
+  }
+}

--- a/outland-feature-server/src/test/java/outland/feature/server/features/VersionsTest.java
+++ b/outland-feature-server/src/test/java/outland/feature/server/features/VersionsTest.java
@@ -1,0 +1,164 @@
+package outland.feature.server.features;
+
+import org.junit.Test;
+
+import static junit.framework.TestCase.assertSame;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class VersionsTest {
+  
+  @Test
+  public void sendPhysicalTimeInThePast() {
+    final long inThePast = 1489018784131L;
+
+    final Versions.Clock clock = () -> inThePast;
+
+    Versions v = new Versions(clock);
+    final Versions.HybridLogicalTimestamp send = v.nextVersion();
+    final Versions.HybridLogicalTimestamp send1 = v.nextVersion();
+
+    // when our physical clock is stuck, only the counter moves forward
+    assertEquals(send.logicalTime(), send1.logicalTime());
+    assertTrue(send.counter() < send1.counter());
+    assertSame(send.counter(), send1.counter() - 1);
+  }
+
+  @Test
+  public void sendPhysicalTimeInTheFuture() {
+
+    final int[] calls = {0};
+
+    final Versions.Clock clock = () -> {
+
+      if (calls[0]++ == 0) {
+        return (System.currentTimeMillis() * 1000L);
+      }
+
+      return (System.currentTimeMillis() * 1000L) + Versions.MAX_SYSTEM_TIME_FORWARD_DRIFT + 1;
+    };
+
+    Versions v = new Versions(clock);
+    final Versions.HybridLogicalTimestamp send = v.nextVersion();
+    final Versions.HybridLogicalTimestamp send1 = v.nextVersion();
+
+    // when our physical clock is too far ahead, only the counter moves forward
+    assertEquals(send.logicalTime(), send1.logicalTime());
+    assertTrue(send.counter() < send1.counter());
+    assertSame(send.counter(), send1.counter() - 1);
+  }
+
+  @Test
+  public void sendPhysicalTime() {
+
+    // a clock that always moves forward
+    final long[] epoch = {System.currentTimeMillis() * 1000L};
+    final Versions.Clock clock = () -> epoch[0]++;
+
+    Versions v = new Versions(clock);
+
+    final Versions.HybridLogicalTimestamp send = v.nextVersion();
+    final Versions.HybridLogicalTimestamp send1 = v.nextVersion();
+
+    // when the physical clock makes progress, the logical time increases and the counters don't
+    assertTrue(send.logicalTime() < send1.logicalTime());
+    assertEquals(send.counter(), send1.counter());
+    assertEquals(send.counter(), send1.counter());
+  }
+
+  @Test
+  public void updateOlder() {
+
+    final long[] epoch = {System.currentTimeMillis() * 1000L};
+    final Versions.Clock clock = () -> ++epoch[0];
+
+    Versions v = new Versions(clock);
+
+    Versions.HybridLogicalTimestamp older =
+        new Versions.HybridLogicalTimestamp(0L, 0L);
+
+    final Versions.HybridLogicalTimestamp send = v.nextVersion();
+
+    // precondition check we're actually ahead
+    assertTrue(send.logicalTime() > older.logicalTime());
+
+    // update
+    final Versions.HybridLogicalTimestamp receive = v.nextVersionUpdate(older);
+
+    // stayed ahead
+    assertTrue(receive.logicalTime() > older.logicalTime());
+    // moved head
+    assertTrue(receive.logicalTime() > send.logicalTime());
+  }
+
+  @Test
+  public void updateNewer() {
+
+    final long[] epoch = {System.currentTimeMillis() * 1000L};
+    final Versions.Clock clock = () -> ++epoch[0];
+
+    Versions v = new Versions(clock);
+
+    final Versions.HybridLogicalTimestamp nextVersion = v.nextVersion();
+
+    final long recent = clock.timestampMicros() + 10; // push the incoming time fwd
+
+    Versions.HybridLogicalTimestamp newerIncoming =
+        new Versions.HybridLogicalTimestamp(recent, 0L);
+
+    // precondition check we're actually getting more recent
+    assertTrue(nextVersion.logicalTime() < newerIncoming.logicalTime());
+
+    final Versions.HybridLogicalTimestamp versionUpdate = v.nextVersionUpdate(newerIncoming);
+
+    // took the newer time and bumped its counter
+    assertEquals(newerIncoming.logicalTime(), versionUpdate.logicalTime());
+    assertTrue(newerIncoming.counter() == versionUpdate.counter() - 1);
+
+    // moved ahead from our last nextVersion
+    assertTrue(versionUpdate.logicalTime() > nextVersion.logicalTime());
+  }
+
+  @Test
+  public void updateSame() {
+    final long[] epoch = {System.currentTimeMillis() * 1000L};
+    final Versions.Clock clock = () -> epoch[0];
+
+    Versions v = new Versions(clock);
+
+    final Versions.HybridLogicalTimestamp nextVersion = v.nextVersion();
+
+    Versions.HybridLogicalTimestamp incoming =
+        new Versions.HybridLogicalTimestamp(clock.timestampMicros(), 1L);
+
+    // precondition check we're actually getting the same time/counter
+    assertEquals(nextVersion.logicalTime(), incoming.logicalTime());
+    assertEquals(nextVersion.counter(), incoming.counter());
+
+    final Versions.HybridLogicalTimestamp versionUpdate = v.nextVersionUpdate(incoming);
+
+    // the time will be the same, just bumped the counter
+    assertEquals(incoming.logicalTime(), versionUpdate.logicalTime());
+    assertTrue(incoming.counter() == versionUpdate.counter() - 1);
+    assertTrue(nextVersion.counter() == versionUpdate.counter() - 1);
+
+    // now try with a bigger incoming counter
+
+    Versions.HybridLogicalTimestamp incomingAgain =
+        new Versions.HybridLogicalTimestamp(clock.timestampMicros(), 5L);
+
+    final Versions.HybridLogicalTimestamp versionUpdateAgain = v.nextVersionUpdate(incomingAgain);
+
+    // the time will be the same, just bumped the counter to use the incoming
+    assertEquals(incomingAgain.logicalTime(), versionUpdateAgain.logicalTime());
+    assertTrue(incomingAgain.counter() == versionUpdateAgain.counter() - 1);
+
+    // and again with an already seen incoming and its lower counter
+    final Versions.HybridLogicalTimestamp versionUpdateAgainAgain =
+        v.nextVersionUpdate(incomingAgain);
+
+    assertEquals(incomingAgain.logicalTime(), versionUpdateAgain.logicalTime());
+    assertTrue(versionUpdateAgain.counter() > incomingAgain.counter());
+    assertTrue(versionUpdateAgain.counter() == versionUpdateAgainAgain.counter() - 1);
+  }
+}


### PR DESCRIPTION
This allows the server to generate sortable version numbers using a timestamp
and a counter. It's a hacked up impl based on hybrid logical clocks
(https://www.cse.buffalo.edu/tech-reports/2014-04.pdf) with a guard to check
if the local system time has moved "too far" into the future. If it has the
counter is bumped and the last logical time is kept instead.