### PR TITLE
Changes the order of arguments for client enabled and select calls.

### DIFF
--- a/outland-feature-java/src/main/java/outland/feature/FeatureClient.java
+++ b/outland-feature-java/src/main/java/outland/feature/FeatureClient.java
@@ -258,14 +258,14 @@ public class FeatureClient {
    * want to throw an exception for a missing feature, use {@link #enabledThrowing}.
    * </p>
    *
-   * @param group the group the feature belongs to.
    * @param featureKey the feature key defined for the feature
+   * @param group the group the feature belongs to.
    * @return true if the feature is enabled. Returns false if the feature is not enabled, not known,
    * or there was an internal error.
    * @throws FeatureException if the supplied featureKey is null, or, the default group has not been
    * configured.
    */
-  public boolean enabled(String group, String featureKey) {
+  public boolean enabled(String featureKey, String group) {
     FeatureException.throwIfNullOrEmpty(group, "Please supply a defaultGroup");
     FeatureException.throwIfNullOrEmpty(featureKey, "Please supply a featureKey");
 
@@ -279,14 +279,14 @@ public class FeatureClient {
    * {@link FeatureException} if the feature does not exist or there is an internal exception.
    * </p>
    *
-   * @param group the group the feature belongs to.
    * @param featureKey the feature key defined for the feature
+   * @param group the group the feature belongs to.
    * @return true if the feature is enabled ({@link State#on}). Returns false if the feature is not
    * enabled ({@link State#off}).
    * @throws FeatureException if the supplied featureKey is null, the default group has not been
    * configured, the feature does not exist or there was an internal error.
    */
-  public boolean enabledThrowing(String group, String featureKey) {
+  public boolean enabledThrowing(String featureKey, String group) {
     FeatureException.throwIfNullOrEmpty(group, "Please supply a defaultGroup");
     FeatureException.throwIfNullOrEmpty(featureKey, "Please supply a featureKey");
 
@@ -330,13 +330,13 @@ public class FeatureClient {
    * {@link #selectBooleanThrowing(String, String)}.
    * </p>
    *
-   * @param group the group the feature belongs to.
    * @param featureKey the feature key defined for the feature
+   * @param group the group the feature belongs to.
    * @return true if the feature selects to "true". Returns false if the feature selects to "false".
    * Always return false if the feature is set to {@link State#off}.
    * @throws FeatureException if the supplied group or featureKey is null.
    */
-  public boolean selectBoolean(String group, String featureKey) {
+  public boolean selectBoolean(String featureKey, String group) {
     FeatureException.throwIfNull(group, "Please supply a group");
     FeatureException.throwIfNull(featureKey, "Please supply a featureKey");
 
@@ -371,14 +371,14 @@ public class FeatureClient {
    * was not a bool type.
    * </p>
    *
-   * @param group the group the feature belongs to.
    * @param featureKey the feature key defined for the feature
+   * @param group the group the feature belongs to.
    * @return true if the feature selects to "true". Returns false if the feature selects to "false".
    * Always return false if the feature is set to  {@link State#off}.
    * @throws FeatureException if the supplied group or featureKey is null, the feature does not
    * exist, or is not a boolean option type.
    */
-  public boolean selectBooleanThrowing(String group, String featureKey) {
+  public boolean selectBooleanThrowing(String featureKey, String group) {
     FeatureException.throwIfNullOrEmpty(group, "Please supply a group");
     FeatureException.throwIfNullOrEmpty(featureKey, "Please supply a featureKey");
 
@@ -418,12 +418,12 @@ public class FeatureClient {
    * feature, call {@link #selectStringThrowing(String, String)}.
    * </p>
    *
-   * @param group the group the feature belongs to.
    * @param featureKey the feature key defined for the feature
+   * @param group the group the feature belongs to.
    * @return the selected option or the control value if the feature is set to {@link State#off}.
    * @throws FeatureException if the supplied group or featureKey is null.
    */
-  public String selectString(String group, String featureKey) {
+  public String selectString(String featureKey, String group) {
     FeatureException.throwIfNullOrEmpty(group, "Please supply a group");
     FeatureException.throwIfNullOrEmpty(featureKey, "Please supply a featureKey");
 
@@ -447,7 +447,7 @@ public class FeatureClient {
   public String selectStringThrowing(String featureKey) {
     FeatureException.throwIfNullOrEmpty(featureKey, "Please supply a featureKey");
 
-    return selectThrowing(defaultGroup, featureKey);
+    return selectThrowing(featureKey, defaultGroup);
   }
 
   /**
@@ -458,17 +458,17 @@ public class FeatureClient {
    * {@link FeatureException} if the feature does not exist or the option type is not a string.
    * </p>
    *
-   * @param group the group the feature belongs to.
    * @param featureKey the feature key defined for the feature
+   * @param group the group the feature belongs to.
    * @return the selected option or the control value if the feature is set to {@link State#off}.
    * @throws FeatureException if the supplied group or featureKey is null, the feature does not
    * exist, or is not a string option type.
    */
-  public String selectStringThrowing(String group, String featureKey) {
+  public String selectStringThrowing(String featureKey, String group) {
     FeatureException.throwIfNullOrEmpty(group, "Please supply a group");
     FeatureException.throwIfNullOrEmpty(featureKey, "Please supply a featureKey");
 
-    return selectThrowing(group, featureKey);
+    return selectThrowing(featureKey, group);
   }
 
   /**
@@ -505,13 +505,13 @@ public class FeatureClient {
    * for a missing feature or a flag call, use {@link #selectStringThrowing(String, String)}.
    * </p>
    *
-   * @param group the group the feature belongs to.
    * @param featureKey the feature key defined for the feature
+   * @param group the group the feature belongs to.
    * @return the selected option, the control value if the feature is set to {@link State#off}, or
    * the empty string if the feature is not found.
    * @throws FeatureException if the supplied group or featureKey is null.
    */
-  public String select(String group, String featureKey) {
+  public String select(String featureKey, String group) {
     FeatureException.throwIfNullOrEmpty(group, "Please supply a group");
     FeatureException.throwIfNullOrEmpty(featureKey, "Please supply a featureKey");
 
@@ -545,13 +545,13 @@ public class FeatureClient {
    * {@link FeatureException} if the feature does not exist or the option type is a flag.
    * </p>
    *
-   * @param group the group the feature belongs to.
    * @param featureKey the feature key defined for the feature
+   * @param group the group the feature belongs to.
    * @return the selected option or the control value if the feature is set to {@link State#off}.
    * @throws FeatureException if the supplied group or featureKey is null, the feature does not
    * exist, or is a flag type.
    */
-  public String selectThrowing(String group, String featureKey) {
+  public String selectThrowing(String featureKey, String group) {
     FeatureException.throwIfNullOrEmpty(group, "Please supply a group");
     FeatureException.throwIfNullOrEmpty(featureKey, "Please supply a featureKey");
 

--- a/outland-feature-java/src/test/java/outland/feature/FeatureClientTest.java
+++ b/outland-feature-java/src/test/java/outland/feature/FeatureClientTest.java
@@ -28,31 +28,31 @@ public class FeatureClientTest {
     expectIllegalArgument(() -> client.enabled(null));
     expectIllegalArgument(() -> client.enabled(""));
 
-    expectIllegalArgument(() -> client.enabled("grp", null));
-    expectIllegalArgument(() -> client.enabled("", "f"));
-    expectIllegalArgument(() -> client.enabled(null, "f"));
-    expectIllegalArgument(() -> client.enabled("g", ""));
+    expectIllegalArgument(() -> client.enabled(null, "grp"));
+    expectIllegalArgument(() -> client.enabled("f", ""));
+    expectIllegalArgument(() -> client.enabled("f", null));
+    expectIllegalArgument(() -> client.enabled("", "g"));
 
-    expectIllegalArgument(() -> client.enabledThrowing("grp", null));
-    expectIllegalArgument(() -> client.enabledThrowing("", "f"));
-    expectIllegalArgument(() -> client.enabledThrowing(null, "f"));
-    expectIllegalArgument(() -> client.enabledThrowing("g", ""));
+    expectIllegalArgument(() -> client.enabledThrowing(null, "grp"));
+    expectIllegalArgument(() -> client.enabledThrowing("f", ""));
+    expectIllegalArgument(() -> client.enabledThrowing("f", null));
+    expectIllegalArgument(() -> client.enabledThrowing("", "g"));
 
     expectIllegalArgument(() -> client.select(""));
     expectIllegalArgument(() -> client.select(null));
 
-    expectIllegalArgument(() -> client.select("", "f"));
-    expectIllegalArgument(() -> client.select(null, "f"));
-    expectIllegalArgument(() -> client.select("g", ""));
-    expectIllegalArgument(() -> client.select("g", null));
+    expectIllegalArgument(() -> client.select("f", ""));
+    expectIllegalArgument(() -> client.select("f", null));
+    expectIllegalArgument(() -> client.select("", "g"));
+    expectIllegalArgument(() -> client.select(null, "g"));
 
     expectIllegalArgument(() -> client.selectThrowing("" ));
     expectIllegalArgument(() -> client.selectThrowing(null ));
 
-    expectIllegalArgument(() -> client.selectThrowing("", "f"));
-    expectIllegalArgument(() -> client.selectThrowing(null, "f"));
-    expectIllegalArgument(() -> client.selectThrowing("g", ""));
-    expectIllegalArgument(() -> client.selectThrowing("g", null));
+    expectIllegalArgument(() -> client.selectThrowing("f", ""));
+    expectIllegalArgument(() -> client.selectThrowing("f", null));
+    expectIllegalArgument(() -> client.selectThrowing("", "g"));
+    expectIllegalArgument(() -> client.selectThrowing(null, "g"));
 
     expectIllegalArgument(() -> client.selectBoolean(""));
     expectIllegalArgument(() -> client.selectBoolean(null));
@@ -60,26 +60,26 @@ public class FeatureClientTest {
     expectIllegalArgument(() -> client.selectBooleanThrowing(""));
     expectIllegalArgument(() -> client.selectBooleanThrowing(null));
 
-    expectIllegalArgument(() -> client.selectBooleanThrowing("", "f"));
-    expectIllegalArgument(() -> client.selectBooleanThrowing(null, "f"));
-    expectIllegalArgument(() -> client.selectBooleanThrowing("g", ""));
-    expectIllegalArgument(() -> client.selectBooleanThrowing("g", null));
+    expectIllegalArgument(() -> client.selectBooleanThrowing("f", ""));
+    expectIllegalArgument(() -> client.selectBooleanThrowing("f", null));
+    expectIllegalArgument(() -> client.selectBooleanThrowing("", "g"));
+    expectIllegalArgument(() -> client.selectBooleanThrowing(null, "g"));
 
     expectIllegalArgument(() -> client.selectString(""));
     expectIllegalArgument(() -> client.selectString(null));
 
-    expectIllegalArgument(() -> client.selectString("", "f"));
-    expectIllegalArgument(() -> client.selectString(null, "f"));
-    expectIllegalArgument(() -> client.selectString("g", ""));
-    expectIllegalArgument(() -> client.selectString("g", null));
+    expectIllegalArgument(() -> client.selectString("f", ""));
+    expectIllegalArgument(() -> client.selectString("f", null));
+    expectIllegalArgument(() -> client.selectString("", "g"));
+    expectIllegalArgument(() -> client.selectString(null, "g"));
 
     expectIllegalArgument(() -> client.selectStringThrowing(""));
     expectIllegalArgument(() -> client.selectStringThrowing(null));
 
-    expectIllegalArgument(() -> client.selectStringThrowing("", "f"));
-    expectIllegalArgument(() -> client.selectStringThrowing(null, "f"));
-    expectIllegalArgument(() -> client.selectStringThrowing("g", ""));
-    expectIllegalArgument(() -> client.selectStringThrowing("g", null));
+    expectIllegalArgument(() -> client.selectStringThrowing("f", ""));
+    expectIllegalArgument(() -> client.selectStringThrowing("f", null));
+    expectIllegalArgument(() -> client.selectStringThrowing("", "g"));
+    expectIllegalArgument(() -> client.selectStringThrowing(null, "g"));
   }
 
   private void expectIllegalArgument(Supplier supplier) {


### PR DESCRIPTION
Group now trails feature key as that reads more naturally from the
plain feature key calls as an extension argument. It also leaves
room to add another set of calls that have a third namespace argument.